### PR TITLE
Make button invisible if plugin returns no output

### DIFF
--- a/argos@pew.worldwidemann.com/button.js
+++ b/argos@pew.worldwidemann.com/button.js
@@ -136,6 +136,11 @@ var ArgosButton = new Lang.Class({
       this._cycleTimeout = null;
     }
 
+    this.actor.visible = buttonLines.length > 0 || !dropdownMode;
+
+    if (!this.actor.visible)
+      return;
+
     if (buttonLines.length === 0) {
       this._lineView.setMarkup(GLib.markup_escape_text(this._file.get_basename(), -1));
     } else if (buttonLines.length === 1) {


### PR DESCRIPTION
This hides the indicator for a plugin if the plugin returns no output (see #49).