### PR TITLE
Allow Backslash Escaping of Pipes

### DIFF
--- a/argos@pew.worldwidemann.com/utilities.js
+++ b/argos@pew.worldwidemann.com/utilities.js
@@ -74,6 +74,10 @@ function parseLine(lineString) {
 
   let separatorIndex = lineString.indexOf("|");
 
+  while(lineString.substr(separatorIndex-1,1) == '\\'){
+      separatorIndex = lineString.indexOf("|", separatorIndex+1);
+  }
+
   if (separatorIndex >= 0) {
     let attributes = [];
     try {


### PR DESCRIPTION
This little change would allow to use pipes in your output. My usecase was to be able to print `figlet` output inside argos.

It **simply** checks if there is a backslash in front of the pipe. So it might confuse properly escaped backslashes (like `echo "This is a backslash \\|bash=\"sleep 10\""`, but it will not confuse if spaces are used around the pipe (`echo "This is a backslash \\ | bash=\"sleep 10\""`) as in every example...

PS: I hope it's okay to not have opened an issue beforehand. 