### PR TITLE
Adding a linked badge to the gnome extensions page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[<img width="250" align="right" src="https://gitlab.gnome.org/Teams/Engagement/marketing-design/uploads/82ba0c5d9fe7e103da3c3ee78b77d117/GNOMEExtension-button.svg">](https://extensions.gnome.org/extension/1176/argos/)
 <h1 align="center">Argos</h1>
 <h3 align="center">Create GNOME Shell extensions in seconds</h3>
 <br>


### PR DESCRIPTION
Totally liked the idea in #67 and added the logo + link to the readme. I used the SVG file from gitlab. It should be available there for quite some time...