### PR TITLE
Remove deprecated terminal option "-e"

### DIFF
--- a/argos@pew.worldwidemann.com/menuitem.js
+++ b/argos@pew.worldwidemann.com/menuitem.js
@@ -61,7 +61,7 @@ var ArgosMenuItem = new Lang.Class({
           if (activeLine.terminal === "false") {
             argv = ["bash", "-c", activeLine.bash];
           } else {
-            // Run bash immediately after executing the command to keep the terminal window open
+             // Run shell immediately after executing the command to keep the terminal window open
             // (see http://stackoverflow.com/q/3512055)
             argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec ${SHELL:=bash}"];
           }

--- a/argos@pew.worldwidemann.com/menuitem.js
+++ b/argos@pew.worldwidemann.com/menuitem.js
@@ -63,7 +63,7 @@ var ArgosMenuItem = new Lang.Class({
           } else {
             // Run bash immediately after executing the command to keep the terminal window open
             // (see http://stackoverflow.com/q/3512055)
-            argv = ["gnome-terminal", "-e", "bash -c " + GLib.shell_quote(activeLine.bash + "; exec bash")];
+            argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec $SHELL"];
           }
 
           let [success, pid] = GLib.spawn_async(

--- a/argos@pew.worldwidemann.com/menuitem.js
+++ b/argos@pew.worldwidemann.com/menuitem.js
@@ -63,7 +63,7 @@ var ArgosMenuItem = new Lang.Class({
           } else {
             // Run bash immediately after executing the command to keep the terminal window open
             // (see http://stackoverflow.com/q/3512055)
-            argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec $SHELL"];
+            argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec ${SHELL:=bash}"];
           }
 
           let [success, pid] = GLib.spawn_async(

--- a/argos@pew.worldwidemann.com/menuitem.js
+++ b/argos@pew.worldwidemann.com/menuitem.js
@@ -61,7 +61,7 @@ var ArgosMenuItem = new Lang.Class({
           if (activeLine.terminal === "false") {
             argv = ["bash", "-c", activeLine.bash];
           } else {
-             // Run shell immediately after executing the command to keep the terminal window open
+            // Run shell immediately after executing the command to keep the terminal window open
             // (see http://stackoverflow.com/q/3512055)
             argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec ${SHELL:=bash}"];
           }


### PR DESCRIPTION
Replacing deprecated `-e` option from `gnome-terminal`.

Also using the user's default shell (`$SHELL`; if set) after script execution with fallbach to "bash" if `SHELL` is not set.

See #52 