### PR TITLE
Use registerClass to make plugin compatible with gnome 3.36.

### DIFF
--- a/argos@pew.worldwidemann.com/menuitem.js
+++ b/argos@pew.worldwidemann.com/menuitem.js
@@ -10,6 +10,7 @@
  */
 
 const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const PopupMenu = imports.ui.popupMenu;
@@ -18,64 +19,70 @@ const AltSwitcher = imports.ui.status.system.AltSwitcher;
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const ArgosLineView = Extension.imports.lineview.ArgosLineView;
 
-var ArgosMenuItem = class extends PopupMenu.PopupBaseMenuItem {
-  constructor(button, line, alternateLine) {
-    let hasAction = line.hasAction || (typeof alternateLine !== "undefined" && alternateLine.hasAction);
+// Menu entry representing a docker container
+const ArgosMenuItem = GObject.registerClass(
+  {
+      GTypeName: 'ArgosMenuItem'
+  },
+  class extends PopupMenu.PopupBaseMenuItem {
+    _init(button, line, alternateLine) {
+      let hasAction = line.hasAction || (typeof alternateLine !== "undefined" && alternateLine.hasAction);
 
-    super({
-      activate: hasAction,
-      hover: hasAction,
-      can_focus: hasAction
-    });
+      super._init({
+        activate: hasAction,
+        hover: hasAction,
+        can_focus: hasAction
+      });
 
-    let altSwitcher = null;
+      let altSwitcher = null;
 
-    let lineView = new ArgosLineView(line);
+      let lineView = new ArgosLineView(line);
 
-    if (typeof alternateLine === "undefined") {
-      this.actor.add_child(lineView);
-    } else {
-      let alternateLineView = new ArgosLineView(alternateLine);
-      altSwitcher = new AltSwitcher(lineView, alternateLineView);
-      lineView.visible = true;
-      alternateLineView.visible = true;
-      this.actor.add_child(altSwitcher.actor);
-    }
+      if (typeof alternateLine === "undefined") {
+        this.actor.add_child(lineView);
+      } else {
+        let alternateLineView = new ArgosLineView(alternateLine);
+        altSwitcher = new AltSwitcher(lineView, alternateLineView);
+        lineView.visible = true;
+        alternateLineView.visible = true;
+        this.actor.add_child(altSwitcher.actor);
+      }
 
-    if (hasAction) {
-      this.connect("activate", Lang.bind(this, function() {
-        let activeLine = (altSwitcher === null) ? line : altSwitcher.actor.get_child().line;
+      if (hasAction) {
+        this.connect("activate", Lang.bind(this, function() {
+          let activeLine = (altSwitcher === null) ? line : altSwitcher.actor.get_child().line;
 
-        if (activeLine.hasOwnProperty("href"))
-          Gio.AppInfo.launch_default_for_uri(activeLine.href, null);
+          if (activeLine.hasOwnProperty("href"))
+            Gio.AppInfo.launch_default_for_uri(activeLine.href, null);
 
-        if (activeLine.hasOwnProperty("eval"))
-          eval(activeLine.eval);
+          if (activeLine.hasOwnProperty("eval"))
+            eval(activeLine.eval);
 
-        if (activeLine.hasOwnProperty("bash")) {
-          let argv = [];
+          if (activeLine.hasOwnProperty("bash")) {
+            let argv = [];
 
-          if (activeLine.terminal === "false") {
-            argv = ["bash", "-c", activeLine.bash];
-          } else {
-            // Run shell immediately after executing the command to keep the terminal window open
-            // (see http://stackoverflow.com/q/3512055)
-            argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec ${SHELL:=bash}"];
+            if (activeLine.terminal === "false") {
+              argv = ["bash", "-c", activeLine.bash];
+            } else {
+              // Run shell immediately after executing the command to keep the terminal window open
+              // (see http://stackoverflow.com/q/3512055)
+              argv = ["gnome-terminal", "--", "bash", "-c", activeLine.bash + "; exec ${SHELL:=bash}"];
+            }
+
+            let [success, pid] = GLib.spawn_async(
+              null, argv, null, GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.DO_NOT_REAP_CHILD, null);
+
+            if (success) {
+              GLib.child_watch_add(GLib.PRIORITY_DEFAULT_IDLE, pid, function() {
+                if (activeLine.refresh === "true")
+                  button.update();
+              });
+            }
+          } else if (activeLine.refresh === "true") {
+            button.update();
           }
-
-          let [success, pid] = GLib.spawn_async(
-            null, argv, null, GLib.SpawnFlags.SEARCH_PATH | GLib.SpawnFlags.DO_NOT_REAP_CHILD, null);
-
-          if (success) {
-            GLib.child_watch_add(GLib.PRIORITY_DEFAULT_IDLE, pid, function() {
-              if (activeLine.refresh === "true")
-                button.update();
-            });
-          }
-        } else if (activeLine.refresh === "true") {
-          button.update();
-        }
-      }));
+        }));
+      }
     }
   }
-};
+);


### PR DESCRIPTION
I realize that there is some sort of maintenance vacuum with this project (as an aside, appreciate the detailed notice - https://github.com/p-e-w/argos/issues/108#issuecomment-585076628, and feel similarly). That said, this PR fixes the compatibility with 3.36 for me, so I figured I'd submit it anyway. It might be useful to someone even if it doesn't get merged. I'm not sure if this breaks Argos on older versions of gnome.

Refs #105 