### PR TITLE
remove redeclaration of _onDestroy()

### DIFF
--- a/argos@pew.worldwidemann.com/button.js
+++ b/argos@pew.worldwidemann.com/button.js
@@ -40,7 +40,7 @@ var ArgosButton = new Lang.Class({
     this._updateTimeout = null;
     this._cycleTimeout = null;
 
-    this.connect("destroy", Lang.bind(this, this._onDestroy));
+    this.connect("destroy", Lang.bind(this, this._onButtonDestroy));
 
     this._updateRunning = false;
 
@@ -54,15 +54,13 @@ var ArgosButton = new Lang.Class({
     }
   },
 
-  _onDestroy: function() {
+  _onButtonDestroy: function() {
     this._isDestroyed = true;
 
     if (this._updateTimeout !== null)
       Mainloop.source_remove(this._updateTimeout);
     if (this._cycleTimeout !== null)
       Mainloop.source_remove(this._cycleTimeout);
-
-    this.menu.removeAll();
   },
 
   update: function() {


### PR DESCRIPTION
_onDestroy() is already present in panelMenu.Button.

https://github.com/GNOME/gnome-shell/blob/e6089c83e2993098814b7056e1c7f54e5dc06820/js/ui/panelMenu.js#L187

So this function is called twice. Put log("### something") into it to check. And proper Button._onDestroy() is not called at all. This leads to shell crash on screen lock (issue #79).

removed this.menu.removeAll() - fix errors in journal because menu is already destroyed.
