### PR TITLE
Javascript Fixes for GNOME shell 42

### DIFF
--- a/argos@pew.worldwidemann.com/button.js
+++ b/argos@pew.worldwidemann.com/button.js
@@ -10,6 +10,7 @@
  */
 
 const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const PanelMenu = imports.ui.panelMenu;
@@ -21,12 +22,14 @@ const ArgosLineView = Extension.imports.lineview.ArgosLineView;
 const ArgosMenuItem = Extension.imports.menuitem.ArgosMenuItem;
 const Utilities = Extension.imports.utilities;
 
-var ArgosButton = new Lang.Class({
-  Name: "ArgosButton",
-  Extends: PanelMenu.Button,
+var ArgosButton = GObject.registerClass({
+  GTypeName: "ArgosButton",
+},
 
-  _init: function(file, settings) {
-    this.parent(0, "", false);
+class ArgosButton extends PanelMenu.Button {
+
+  _init(file, settings) {
+    super._init(0, "", false);
 
     this._file = file;
     this._updateInterval = settings.updateInterval;
@@ -52,9 +55,9 @@ var ArgosButton = new Lang.Class({
           this.update();
       }));
     }
-  },
+  }
 
-  _onDestroy: function() {
+  _onDestroy() {
     this._isDestroyed = true;
 
     if (this._updateTimeout !== null)
@@ -63,18 +66,18 @@ var ArgosButton = new Lang.Class({
       Mainloop.source_remove(this._cycleTimeout);
 
     this.menu.removeAll();
-  },
+  }
 
-  update: function() {
+  update() {
     if (this._updateTimeout !== null) {
       Mainloop.source_remove(this._updateTimeout);
       this._updateTimeout = null;
     }
 
     this._update();
-  },
+  }
 
-  _update: function() {
+  _update() {
     if (this._updateRunning)
       return;
 
@@ -106,9 +109,9 @@ var ArgosButton = new Lang.Class({
       log("Unable to execute file '" + this._file.get_basename() + "': " + error);
       this._updateRunning = false;
     }
-  },
+  }
 
-  _processOutput: function(output) {
+  _processOutput(output) {
     let buttonLines = [];
     let dropdownLines = [];
 

--- a/argos@pew.worldwidemann.com/lineview.js
+++ b/argos@pew.worldwidemann.com/lineview.js
@@ -9,27 +9,29 @@
  * (https://gnu.org/licenses/gpl.html)
  */
 
-const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
-var ArgosLineView = new Lang.Class({
-  Name: "ArgosLineView",
-  Extends: St.BoxLayout,
+var ArgosLineView = GObject.registerClass({
+  GTypeName: "ArgosLineView",
+},
 
-  _init: function(line) {
-    this.parent({
+class ArgosLineView extends St.BoxLayout {
+
+  _init(line) {
+    super._init({
       style_class: "argos-line-view"
     });
 
     if (typeof line !== "undefined")
       this.setLine(line);
-  },
+  }
 
-  setLine: function(line) {
+  setLine(line) {
     this.line = line;
 
     this.remove_all_children();
@@ -105,9 +107,9 @@ var ArgosLineView = new Lang.Class({
         }
       }
     }
-  },
+  }
 
-  setMarkup: function(markup) {
+  setMarkup(markup) {
     this.setLine({
       markup: markup
     });

--- a/argos@pew.worldwidemann.com/metadata.json
+++ b/argos@pew.worldwidemann.com/metadata.json
@@ -4,14 +4,11 @@
   "description": "Create GNOME Shell extensions in seconds",
   "url": "https://github.com/p-e-w/argos",
   "shell-version": [
-    "3.26",
-    "3.28",
-    "3.30",
-    "3.32",
     "3.34",
     "3.36",
     "3.38",
     "40",
-    "41"
+    "41",
+    "42"
   ]
 }

--- a/argos@pew.worldwidemann.com/utilities.js
+++ b/argos@pew.worldwidemann.com/utilities.js
@@ -282,15 +282,24 @@ function getShellVersion(str) {
   let versionParts = str.split(".");
   let versionNumber = 0;
 
-  if (versionParts.length === 2) {
+  if (versionParts.length < 2) {
+    log("Invalid GNOME Shell version '" + str + "'");
+    return 0;
+  }
+
+  let major = Number(versionParts[0]);
+
+  if (major >= 40) {
     // GNOME 40 and newer versioning scheme
     // https://discourse.gnome.org/t/new-gnome-versioning-scheme/4235
     // must be > 3.x.y with x <= 38
+    // For 40.x, the 3rd digit is ignored
     // 40.alpha -> 33997
     // 41.beta  -> 34098
     // 41.rc    -> 34099
     // 41.0     -> 34100
     // 40.1     -> 34001
+    // 40.1.1   -> 34001
     let testReleases = new Map([["alpha", -3], ["beta", -2], ["rc", -1]]);
     let minor = testReleases.get(versionParts[1]);
     let major = Number(versionParts[0]);


### PR DESCRIPTION
Convert `ArgosButton` and `ArgosLineView` to `GObject.registerClass()`.

Unfortunately, this time it seems that we can't maintain backward
compatibility. For reasons I can't explain, until GNOME 41 the "complex"
classes `ArgosButton` and `ArgosLineView` could still be defined using
`Lang.Class()`, therefore we could get away with the simplistic
`makeSimpleClass()` trick to define classes differently for different
GNOME shell versions. Now this doesn't work any more, classes with
multiple methods can't be converted between `Lang.Class()` and
`GObject.registerClass()` syntax without complex text procesing.

This fixes errors like this:

    Mar 25 18:11:49 apollon.suse.de gnome-shell[15049]: JS ERROR: Extension argos@pew.worldwidemann.com: TypeError: Object 0x284558126958 is not a subclass of GObject_Objec>
                                                        _construct@resource:///org/gnome/gjs/modules/script/_legacy.js:536:31
                                                        wrapper@resource:///org/gnome/gjs/modules/script/_legacy.js:83:27
                                                        newClass@resource:///org/gnome/gjs/modules/script/_legacy.js:115:21
                                                        Class@resource:///org/gnome/gjs/modules/script/_legacy.js:66:16
                                                        @/home/mwilck/.local/share/gnome-shell/extensions/argos@pew.worldwidemann.com/button.js:24:19
                                                        @/home/mwilck/.local/share/gnome-shell/extensions/argos@pew.worldwidemann.com/extension.js:18:21
    
I've removed GNOME shell < 3.34 from the compatibility list.
`GObject.registerClass()` should be available in 3.34. So far I have only tested
this with GNOME shell 42.

Testing with other GNOME shell versions (34 - 41) would be appreciated.

