### PR TITLE
Don't set obsolete y-fill property for icons

### DIFF
--- a/argos@pew.worldwidemann.com/lineview.js
+++ b/argos@pew.worldwidemann.com/lineview.js
@@ -76,8 +76,6 @@ class ArgosLineView extends St.BoxLayout {
         texture.set_size(width, height);
 
         this.add_child(texture);
-        // Do not stretch the texture to the height of the container
-        this.child_set_property(texture, "y-fill", false);
       } catch (error) {
         log("Unable to load image from Base64 representation: " + error);
       }


### PR DESCRIPTION
No replacement seems to be necessary. My testing shows that no stretching is performed anyway.

Fixes #146.