### PR TITLE
Add support for GNOME 46

### DIFF
--- a/argos@pew.worldwidemann.com/button.js
+++ b/argos@pew.worldwidemann.com/button.js
@@ -33,7 +33,7 @@ class ArgosButton extends PanelMenu.Button {
 
     this._lineView = new ArgosLineView();
     this._lineView.setMarkup("<small><i>" + GLib.markup_escape_text(file.get_basename(), -1) + " ...</i></small>");
-    Utilities.getActor(this).add_actor(this._lineView);
+    Utilities.getActor(this).add_child(this._lineView);
 
     this._isDestroyed = false;
 

--- a/argos@pew.worldwidemann.com/metadata.json
+++ b/argos@pew.worldwidemann.com/metadata.json
@@ -4,6 +4,7 @@
   "description": "Create GNOME Shell extensions in seconds",
   "url": "https://github.com/p-e-w/argos",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ]
 }


### PR DESCRIPTION
Use `add_child` instead of the removed (not deprecated) `add_actor`

https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-container

- Compatibility with GNOME 45 tested on Fedora 39
- Compatibility with GNOME 46 tested on Fedora 40 beta.

Resolves #157