### PR TITLE
Support for Gnome 47

### DIFF
--- a/argos@pew.worldwidemann.com/metadata.json
+++ b/argos@pew.worldwidemann.com/metadata.json
@@ -5,6 +5,7 @@
   "url": "https://github.com/p-e-w/argos",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ]
 }


### PR DESCRIPTION
Without further in-depth investigation I added 47 as supported `shell-version` in `metadata.json`.

My personal scripts all appear to work as expected.
