### PR TITLE
Add support for GNOME 47

### DIFF
--- a/argos@pew.worldwidemann.com/metadata.json
+++ b/argos@pew.worldwidemann.com/metadata.json
@@ -5,6 +5,7 @@
   "url": "https://github.com/p-e-w/argos",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ]
 }


### PR DESCRIPTION
I tested a bit with just updating metadata.json, and it seems to be working.

Will report back here if something fails in GNOME 47.

Didn't see any obvious problems here either: https://gjs.guide/extensions/upgrading/gnome-shell-47.html