### PR TITLE
Gnome 47 GioInput update

### DIFF
--- a/argos@pew.worldwidemann.com/metadata.json
+++ b/argos@pew.worldwidemann.com/metadata.json
@@ -5,6 +5,7 @@
   "url": "https://github.com/p-e-w/argos",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ]
 }

--- a/argos@pew.worldwidemann.com/utilities.js
+++ b/argos@pew.worldwidemann.com/utilities.js
@@ -14,6 +14,7 @@ import St from 'gi://St';
 import GLib from 'gi://GLib';
 import Clutter from 'gi://Clutter';
 import Gio from 'gi://Gio';
+import GioUnix from 'gi://GioUnix';
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import EMOJI from './emoji.js'
 
@@ -260,7 +261,7 @@ export function spawnWithCallback(workingDirectory, argv, envp, flags, childSetu
   let standardOutput = "";
 
   let stdoutStream = new Gio.DataInputStream({
-    base_stream: new Gio.UnixInputStream({
+    base_stream: new GioUnix.InputStream({
       fd: stdoutFile
     })
   });


### PR DESCRIPTION
This resolves the non-critical error "Gio.UnixInputStream has been moved to a separate platform-specific library. Please update your code to use GioUnix.InputStream instead." as well as adding support for gnome 47 to the metadata.json