### PR TITLE
Fix obsolete Gio to GioUnix

### DIFF
--- a/argos@pew.worldwidemann.com/utilities.js
+++ b/argos@pew.worldwidemann.com/utilities.js
@@ -13,7 +13,7 @@ import GObject from 'gi://GObject';
 import St from 'gi://St';
 import GLib from 'gi://GLib';
 import Clutter from 'gi://Clutter';
-import Gio from 'gi://Gio';
+import GioUnix from 'gi://GioUnix';
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import EMOJI from './emoji.js'
 
@@ -260,7 +260,7 @@ export function spawnWithCallback(workingDirectory, argv, envp, flags, childSetu
   let standardOutput = "";
 
   let stdoutStream = new Gio.DataInputStream({
-    base_stream: new Gio.UnixInputStream({
+    base_stream: new GioUnix.InputStream({
       fd: stdoutFile
     })
   });


### PR DESCRIPTION
At Ubuntu 24.10 Gnome shell complaints about Gio being phased out in favor of GioUnix. This PR fixes that