### PR TITLE
fix: prevent exception in logs when using base64 image

### DIFF
--- a/argos@pew.worldwidemann.com/lineview.js
+++ b/argos@pew.worldwidemann.com/lineview.js
@@ -77,7 +77,7 @@ class ArgosLineView extends St.BoxLayout {
 
         this.add_child(texture);
         // Do not stretch the texture to the height of the container
-        this.child_set_property(texture, "y-fill", false);
+        texture.set_y_expand(false);
       } catch (error) {
         log("Unable to load image from Base64 representation: " + error);
       }


### PR DESCRIPTION
In the logs:

```
journalctl --user -f | grep -i gnome-shell
```

I get:

```
Unable to load image from Base64 representation: TypeError: this.child_set_property is not a function
```

On each update. My menu contains a base64 image. 

I don't know gnome at all, but I feel that my replacement suggestion has the same intent.
I didn't notice any breaking on my side.

Do you want a minimal reproducing case ?